### PR TITLE
Fix buffer overflow bug in peak array

### DIFF
--- a/microphone_esp8266_fft/Arduino/microphone_esp8266_fft/microphone_esp8266_fft.ino
+++ b/microphone_esp8266_fft/Arduino/microphone_esp8266_fft/microphone_esp8266_fft.ino
@@ -19,7 +19,7 @@ arduinoFFT FFT = arduinoFFT();
 int amplitude = 200;
 unsigned int sampling_period_us;
 unsigned long microseconds;
-byte peak[] = {0, 0, 0, 0, 0, 0, 0};
+byte peak[] = {0, 0, 0, 0, 0, 0, 0, 0};
 double vReal[SAMPLES];
 double vImag[SAMPLES];
 unsigned long newTime, oldTime;


### PR DESCRIPTION
The peak array is only 7 bytes long, but there are 8 bytes written to it. This overwrites the variable, that the compiler decides to put afterwards, most likely the sample buffer vReal[]. Maybe this is also the reason why you decided to omit the first sample when iterating through vReal[]?